### PR TITLE
Containerless Services and Aliases

### DIFF
--- a/lib/Bread/Board.pm
+++ b/lib/Bread/Board.pm
@@ -110,6 +110,7 @@ sub service ($@) {
     else {
         confess "I don't understand @_";
     }
+    return $s unless defined $CC;
     $CC->add_service($s);
 }
 
@@ -123,7 +124,7 @@ sub alias ($$@) {
         aliased_from_path => $path,
         %params,
     );
-
+    return $s unless defined $CC;
     $CC->add_service($s);
 }
 

--- a/t/151_sugar_no_container.t
+++ b/t/151_sugar_no_container.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Moose;
+
+BEGIN {
+    use_ok('Bread::Board');
+}
+
+{
+    package FileLogger;
+    use Moose;
+    has 'log_file' => (is => 'ro', required => 1);
+
+    package MyApplication;
+    use Moose;
+    has 'logger' => (is => 'ro', isa => 'FileLogger', required => 1);
+}
+
+
+my $file_service = service 'log_file' => "logfile.log";
+
+does_ok($file_service, 'Bread::Board::Service');
+
+my $logger_service = service 'logger' => (
+    class        => 'FileLogger',
+    lifecycle    => 'Singleton',
+    dependencies => {
+        log_file => depends_on('log_file'),
+    }
+);
+
+does_ok($logger_service, 'Bread::Board::Service');
+
+my $app_service = service 'application' => (
+    class        => 'MyApplication',
+    dependencies => {
+        logger => depends_on('logger'),
+    }
+);
+
+does_ok($app_service, 'Bread::Board::Service');
+
+my $bunyan_service = alias 'paul_bunyan' => 'logger';
+
+does_ok($bunyan_service, 'Bread::Board::Service');
+isa_ok($bunyan_service, 'Bread::Board::Service::Alias');
+
+my $c = container 'MyApp';
+
+isa_ok($c, 'Bread::Board::Container');
+
+foreach ( $file_service, $logger_service, $app_service, $bunyan_service) {
+    $c->add_service($_);
+}
+
+my $logger = $c->resolve( service => 'logger' );
+isa_ok($logger, 'FileLogger');
+
+is($logger->log_file, 'logfile.log', '... got the right logfile dep');
+
+is($c->fetch('logger/log_file')->service, $c->fetch('log_file'), '... got the right value');
+is($c->fetch('logger/log_file')->get, 'logfile.log', '... got the right value');
+
+my $app = $c->resolve( service => 'application' );
+isa_ok($app, 'MyApplication');
+
+isa_ok($app->logger, 'FileLogger');
+is($app->logger, $logger, '... got the right logger (singleton)');
+
+my $bunyan = $c->resolve( service => 'paul_bunyan' );
+isa_ok($bunyan, 'FileLogger');
+is($bunyan, $logger, 'standalone alias works.');
+
+done_testing();


### PR DESCRIPTION
Allow service() and alias() sugar functions to return the newly-created objects if the context container is not defined.
