### PR TITLE
_build_parameters instead of default

### DIFF
--- a/lib/Bread/Board/Service/WithParameters.pm
+++ b/lib/Bread/Board/Service/WithParameters.pm
@@ -15,7 +15,7 @@ has 'parameters' => (
     isa       => 'Bread::Board::Service::Parameters',
     lazy      => 1,
     coerce    => 1,
-    default   => sub { +{} },
+    builder   => '_build_parameters',
     handles   => {
         'has_parameters' => 'count'
     }
@@ -41,6 +41,10 @@ after 'get' => sub {
     map { $self->_clear_param( $_ ) } @{ $self->_parameter_keys_to_remove };
     $self->_clear_parameter_keys_to_remove;
 };
+
+sub _build_parameters {
+    return +{};
+}
 
 sub check_parameters {
     my $self = shift;


### PR DESCRIPTION
When one needs to extend the WithParameters.pm role, it is a lot easier to override the default parameters using a builder.
I'm needing that for Catalyst.
