### PR TITLE
Bread::Board should not have a ->new method

### DIFF
--- a/lib/Bread/Board.pm
+++ b/lib/Bread/Board.pm
@@ -1,5 +1,8 @@
 package Bread::Board;
-use Moose;
+use strict;
+use warnings;
+use Carp qw(confess);
+use Scalar::Util qw(blessed);
 
 use Bread::Board::Types;
 use Bread::Board::ConstructorInjection;
@@ -178,9 +181,7 @@ sub depends_on ($) {
     Bread::Board::Dependency->new(service_path => $path);
 }
 
-__PACKAGE__->meta->make_immutable;
-
-no Moose; 1;
+1;
 
 __END__
 

--- a/t/300_no_new.t
+++ b/t/300_no_new.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Bread::Board ();
+
+ok !Bread::Board->can("new");
+
+done_testing;
+


### PR DESCRIPTION
You never want to make an instance of it, as it's just a sugar exporting module
