### PR TITLE
add a dump method

### DIFF
--- a/lib/Bread/Board/Container.pm
+++ b/lib/Bread/Board/Container.pm
@@ -3,6 +3,9 @@ use Moose;
 use Moose::Util::TypeConstraints 'find_type_constraint';
 use MooseX::Params::Validate;
 
+use namespace::autoclean;
+use Class::Load 0.20 'load_class';
+
 use Bread::Board::Types;
 
 use namespace::autoclean;
@@ -174,6 +177,12 @@ sub resolve {
         confess "Cannot call resolve without telling it what to resolve.";
     }
 
+}
+
+sub dump {
+    my $self = shift;
+
+    load_class('Bread::Board::Dumper')->new->dump( $self );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/010_container.t
+++ b/t/010_container.t
@@ -53,6 +53,11 @@ my $app = $c->get_sub_container('Application');
 isa_ok($app, 'Bread::Board::Container');
 
 ok ! $app->can('find_type_constraint'), 'can not find_type_constraint';
+ok ! $app->can('load_class'),           'can not load_class';
+
+can_ok $app, 'dump';
+
+like $app->dump, qr/Application/, 'dump mentions Application';
 
 is($app->name, 'Application', '... got the right container');
 


### PR DESCRIPTION
I'm adding a dump method to your container, I was a little frustrated by having to import Bread::Board::Dumper just to use it's dump, so this encapsulates that on the container itself.

I also fixed a bug were you were accidentally exposing `find_type_constraint` on the container. They are in separate patches.
