### PR TITLE
add roles when using constructor injection

### DIFF
--- a/lib/Bread/Board/ConstructorInjection.pm
+++ b/lib/Bread/Board/ConstructorInjection.pm
@@ -7,7 +7,8 @@ use Bread::Board::Types;
 
 with 'Bread::Board::Service::WithClass',
      'Bread::Board::Service::WithParameters',
-     'Bread::Board::Service::WithDependencies';
+     'Bread::Board::Service::WithDependencies',
+     'Bread::Board::Service::WithRoles';
 
 has 'constructor_name' => (
     is       => 'rw',

--- a/lib/Bread/Board/Service/WithRoles.pm
+++ b/lib/Bread/Board/Service/WithRoles.pm
@@ -1,0 +1,34 @@
+package Bread::Board::Service::WithRoles;
+use Moose::Role;
+
+use Bread::Board::Types;
+
+with 'Bread::Board::Service';
+
+has 'roles' => (
+    is        => 'rw',
+    isa       => 'ArrayRef[Str]',
+    traits    => ['Array'],
+    lazy      => 1,
+    default   => sub { +[] },
+    handles   => {
+        has_roles  => 'count',
+        list_roles => 'elements',
+    },
+);
+
+before 'get' => sub {
+    my $self = shift;
+
+    if ( $self->has_roles ) {
+		
+        foreach my $role ( $self->list_roles ) {
+            Module::Runtime::use_package_optimistically( $role );
+        }
+        my $class = Moose::Util::with_traits( $self->class, $self->list_roles );
+        $class->meta->make_immutable if $self->has_roles;
+		$self->class( $class );
+    }
+};
+
+no Moose::Role; 1;

--- a/t/006_constructor_injection_w_roles.t
+++ b/t/006_constructor_injection_w_roles.t
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Moose;
+use Test::Fatal;
+
+use Bread::Board::ConstructorInjection;
+use Bread::Board::Literal;
+
+{
+    package Sterile;
+    use Moose::Role;
+
+    package Needle;
+    use Moose;
+
+    package Mexican::Black::Tar;
+    use Moose;
+
+    package Addict;
+    use Moose;
+
+    sub shoot_up_good { shift->new(@_, overdose => 1) }
+
+    has 'needle' => (is => 'ro');
+    has 'spoon'  => (is => 'ro');
+    has 'stash'  => (is => 'ro');
+    has 'overdose' => (is => 'ro', isa => 'Bool', default => 0);
+}
+
+my $s = Bread::Board::ConstructorInjection->new(
+    name  => 'William',
+    class => 'Addict',
+    dependencies => {
+        needle => Bread::Board::ConstructorInjection->new(
+			name  => 'spike',
+			class => 'Needle',
+			roles => ['Sterile'], # I need sterile needle's yo
+		),
+        spoon  => Bread::Board::Literal->new(name => 'works', value => 'Spoon!'),
+    },
+    parameters => {
+        stash => { isa => 'Mexican::Black::Tar' }
+    }
+);
+isa_ok($s, 'Bread::Board::ConstructorInjection');
+does_ok($s, 'Bread::Board::Service::WithClass');
+does_ok($s, 'Bread::Board::Service::WithDependencies');
+does_ok($s, 'Bread::Board::Service::WithParameters');
+does_ok($s, 'Bread::Board::Service');
+
+{
+    my $i = $s->get(stash => Mexican::Black::Tar->new);
+
+    isa_ok($i, 'Addict');
+    isa_ok($i->needle, 'Needle');
+	does_ok( $i->needle, 'Sterile' );
+	ok( $i->needle->meta->is_immutable, 'is immutable' );
+    is($i->spoon, 'Spoon!', '... got our literal service');
+    isa_ok($i->stash, 'Mexican::Black::Tar');
+    ok ! $i->overdose, 'Normal constructor';
+}
+
+done_testing;

--- a/t/081_infer_w_roles.t
+++ b/t/081_infer_w_roles.t
@@ -1,0 +1,91 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+use Bread::Board;
+
+{
+    package NonMoose;
+    sub new { bless { data => $_[0] }, shift }
+}
+
+{
+    package Foo;
+    use Moose;
+}
+
+{
+    package Bar;
+    use Moose;
+
+    has foo => (
+        is       => 'ro',
+        isa      => 'Foo',
+        required => 1,
+    );
+}
+
+{
+	package NotMoosey;
+	use Moose::Role;
+
+    has non_moose => (
+        is       => 'ro',
+        isa      => 'NonMoose',
+        required => 1,
+    );
+}
+
+{
+    package Bar;
+    use Moose;
+
+    has foo => (
+        is       => 'ro',
+        isa      => 'Foo',
+        required => 1,
+    );
+}
+
+{
+    my $c = container Stuff => as {
+        service non_moose => NonMoose->new("foo");
+        service foo => (
+            class        => 'Foo',
+			roles        => ['NotMoosey']
+        );
+        typemap 'Foo' => 'foo';
+        typemap 'Bar' => infer;
+    };
+
+    my $bar = $c->resolve(type => 'Bar');
+    isa_ok($bar->foo->non_moose, 'NonMoose');
+}
+
+done_testing;
+__END__
+
+{
+    package Foo::Sub;
+    use Moose;
+
+    extends 'Foo';
+}
+
+{
+    my $c = container Stuff => as {
+        service non_moose => NonMoose->new("foo");
+        service foo => (
+            class        => 'Foo::Sub',
+            dependencies => ['non_moose'],
+        );
+        typemap 'Foo::Sub' => 'foo';
+        typemap 'Bar' => infer;
+    };
+
+    my $bar = $c->resolve(type => 'Bar');
+    isa_ok($bar->foo->non_moose, 'NonMoose');
+}
+
+done_testing;


### PR DESCRIPTION
Bread::Board::ConstructorInjection->new(
  class => 'Foo',
  roles => ['Bar'],
)

the benefit of this is to allow us to modify classes that we may not have
control over modifying the source of at runtime.

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
