### PR TITLE
remove Class::MOP::load_class

### DIFF
--- a/lib/Bread/Board/Service.pm
+++ b/lib/Bread/Board/Service.pm
@@ -1,5 +1,6 @@
 package Bread::Board::Service;
 use Moose::Role;
+use Module::Runtime ();
 
 use Moose::Util::TypeConstraints 'find_type_constraint';
 
@@ -46,7 +47,7 @@ has 'lifecycle' => (
         my $lifecycle_role = $lifecycle =~ /^\+/
                  ? substr($lifecycle, 1)
                  : "Bread::Board::LifeCycle::${lifecycle}";
-        Class::MOP::load_class($lifecycle_role);
+        Module::Runtime::use_package_optimistically($lifecycle_role);
         Class::MOP::class_of($lifecycle_role)->apply($self);
     }
 );

--- a/lib/Bread/Board/Service/WithClass.pm
+++ b/lib/Bread/Board/Service/WithClass.pm
@@ -1,5 +1,6 @@
 package Bread::Board::Service::WithClass;
 use Moose::Role;
+use Module::Runtime ();
 
 use Bread::Board::Types;
 
@@ -13,7 +14,7 @@ has 'class' => (
 
 before 'get' => sub {
     my $self = shift;
-    Class::MOP::load_class($self->class)
+    Module::Runtime::use_package_optimistically($self->class)
         if $self->has_class;
 };
 


### PR DESCRIPTION
use of load_class is deprecated within Moose, removing entirely in favor of
Module::Runtime

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
