### PR TITLE
fixes for array deps

### DIFF
--- a/lib/Bread/Board/Types.pm
+++ b/lib/Bread/Board/Types.pm
@@ -47,18 +47,20 @@ sub _coerce_to_dependency {
             require Bread::Board::BlockInjection;
             my $name = '_ANON_COERCE_' . $ANON_INDEX++ . '_';
             my @deps = map { _coerce_to_dependency($_) } @$dep;
-            my @dep_names = map { $_->[0] } @deps;
+            my @dep_names = map { "${name}DEP_$_" } 0..$#deps;
             $dep = Bread::Board::Dependency->new(
                 service_name => $name,
                 service      => Bread::Board::BlockInjection->new(
                     name         => $name,
-                    dependencies => { map { @$_ } @deps },
+                    dependencies => { map { $dep_names[$_] => $deps[$_]->[1] }
+                                          0..$#deps },
                     block        => sub {
                         my ($s) = @_;
                         return [ map { $s->param($_) } @dep_names ];
                     },
                 ),
             );
+            $dep->service->parent($dep);
         }
         else {
             $dep = Bread::Board::Dependency->new(service_path => $dep);

--- a/t/048_array_deps.t
+++ b/t/048_array_deps.t
@@ -7,6 +7,8 @@ use Test::More;
 
 use Bread::Board::ConstructorInjection;
 use Bread::Board::Literal;
+use Bread::Board::Container;
+use Bread::Board::Dependency;
 
 {
     package Item;
@@ -22,14 +24,44 @@ use Bread::Board::Literal;
     has 'items' => (is => 'ro', isa => 'ArrayRef');
 }
 
-my $s = Bread::Board::ConstructorInjection->new(
-    name => 'list_of_items',
-    class => 'ListOfItems',
-    dependencies => {
-        items => [
-            map {
+subtest 'no container' => sub {
+    my $s = Bread::Board::ConstructorInjection->new(
+        name => 'list_of_items',
+        class => 'ListOfItems',
+        dependencies => {
+            items => [
+                map {
+                    Bread::Board::ConstructorInjection->new(
+                        name => $_,
+                        class => 'Item',
+                        dependencies => {
+                            my_name => Bread::Board::Literal->new(
+                                name => 'item_name',
+                                value => $_,
+                            ),
+                        },
+                    )
+                  }
+                    qw(one two three)
+                ],
+        },
+    );
+
+    my $output = $s->get->as_string;
+    is(
+        $output,
+        'one,two,three',
+        'it worked'
+    );
+};
+
+subtest 'container, no ambiguous path names' => sub {
+    my $c = Bread::Board::Container->new(
+        name => 'list_container',
+        services => [
+            (map {
                 Bread::Board::ConstructorInjection->new(
-                    name => $_,
+                    name => "item_$_",
                     class => 'Item',
                     dependencies => {
                         my_name => Bread::Board::Literal->new(
@@ -39,16 +71,64 @@ my $s = Bread::Board::ConstructorInjection->new(
                     },
                 )
               }
-                qw(one two three)
-            ],
-    },
-);
+                 qw(one two three)),
+            Bread::Board::ConstructorInjection->new(
+                name => 'list_of_items',
+                class => 'ListOfItems',
+                dependencies => {
+                    items => [ map { "item_$_" } qw(one two three) ],
+                },
+            ),
+        ],
+    );
+    my $output = $c->fetch('list_of_items')->get->as_string;
+    is(
+        $output,
+        'one,two,three',
+        'it worked'
+    );
+};
 
-my $output = $s->get->as_string;
-is(
-    $output,
-    'one,two,three',
-    'it worked'
-);
+subtest 'multiple containers, ambiguous names' => sub {
+    my $c = Bread::Board::Container->new(
+        name => 'list_container',
+        sub_containers => [
+            map { Bread::Board::Container->new(
+                name => "$_",
+                services => [
+                    Bread::Board::ConstructorInjection->new(
+                        name => "item",
+                        class => 'Item',
+                        dependencies => {
+                            my_name => Bread::Board::Literal->new(
+                                name => 'item_name',
+                                value => $_,
+                            ),
+                        },
+                    )
+                  ],
+            ) } qw(one two three),
+        ],
+        services => [
+            Bread::Board::ConstructorInjection->new(
+                name => 'list_of_items',
+                class => 'ListOfItems',
+                dependencies => {
+                    # all of these have a service_name of "item", the
+                    # dependency coercion must give them distinct
+                    # names
+                    items => [ map { "/$_/item" } qw(one two three) ],
+                },
+            ),
+        ],
+    );
+
+    my $output = $c->fetch('list_of_items')->get->as_string;
+    is(
+        $output,
+        'one,two,three',
+        'it worked'
+    );
+};
 
 done_testing;


### PR DESCRIPTION
turns out, my initial attempt at array-of-dependencies had a few problems.

1) if the dependency has to be resolved, things broke because the BlockInjection does not know its parent
2) if the dependencies in the array all have the same service_name, the resolver got confused

This commit fixes both issues, and tests both failures.
