### PR TITLE
Replace the use of Moose::Exporter with Exporter so we don't enable s…

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,8 +4,10 @@ Revision history for Bread-Board
   [ API CHANGES ]
 
   [ BUG FIXES ]
-     - fixed Bread::Board::Dumper to dump parameterized containers -
-       previously it would just ignore them entirely (#56, Dave Rolsky)
+    - fixed Bread::Board::Dumper to dump parameterized containers -
+      previously it would just ignore them entirely (#56, Dave Rolsky)
+    - Using Bread::Board no longer enables strict and warnings in the calling
+      package. (#53, Dave Rolsky)
 
   [ DOCUMENTATION ]
 

--- a/lib/Bread/Board.pm
+++ b/lib/Bread/Board.pm
@@ -18,21 +18,38 @@ use Bread::Board::LifeCycle::Singleton;
 use Bread::Board::Service::Inferred;
 use Bread::Board::Service::Alias;
 
-use Moose::Exporter 2.1200;
-Moose::Exporter->setup_import_methods(
-    as_is => [qw[
-        as
-        container
-        depends_on
-        service
-        alias
-        wire_names
-        include
-        typemap
-        infer
-        literal
-    ]],
-);
+use Exporter qw( import );
+
+our @EXPORT = qw[
+    as
+    container
+    depends_on
+    service
+    alias
+    wire_names
+    include
+    typemap
+    infer
+    literal
+];
+
+# This is a chopped down version of what's in Moose::Exporter. It'd be nice if
+# there was something on CPAN that implemented this without all the additional
+# Moose::Exporter baggage (particularly the enabling of strict & warnings).
+sub unimport {
+    my $package = caller();
+
+    foreach my $name (@EXPORT) {
+        no strict 'refs';
+        next unless defined &{ $package . '::' . $name };
+
+        my $sub = \&{ $package . '::' . $name };
+
+        next unless $sub eq __PACKAGE__->can($name);
+
+        delete ${ $package . '::' }{$name};
+    }
+}
 
 sub as (&) { $_[0] }
 


### PR DESCRIPTION
…trict & warnings on import

Looking at Bread::Board, I don't see any good reason for it to use
`Moose::Exporter`. That module is really for things that need to wrap some
exports to get at the package's meta objects. If _all_ of the exports are
`as_is` then it's just a more complicated version of `Exporter` that isn't
adding anything, except the unimport functionality, which I've replicated
(more or less).
