### PR TITLE
Allow a literal to be undef

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,8 +10,9 @@ Revision history for Bread-Board
   [ DOCUMENTATION ]
 
   [ ENHANCEMENTS ]
-     - Bread::Board::Dumper now sorts services and sub containers - previously
-       these came out in a random order each time (#56, Dave Rolsky)
+    - Bread::Board::Dumper now sorts services and sub containers - previously
+      these came out in a random order each time (#56, Dave Rolsky)
+    - allow a service or literal to be undefined. (#54, Dave Rolsky)
 
   [ NEW FEATURES ]
 

--- a/lib/Bread/Board/Literal.pm
+++ b/lib/Bread/Board/Literal.pm
@@ -7,7 +7,6 @@ with 'Bread::Board::Service';
 
 has 'value' => (
     is       => 'rw',
-    isa      => 'Defined',
     required => 1,
 );
 

--- a/t/024_sugar.t
+++ b/t/024_sugar.t
@@ -46,6 +46,7 @@ my $c = container 'MyApp' => as {
         service 'dsn'      => "dbi:sqlite:dbname=my-app.db";
         service 'username' => "user";
         service 'password' => "pass";
+        service 'host'     => undef;
 
         service 'dbh' => (
             block => sub {
@@ -77,6 +78,8 @@ is($logger->log_file, 'logfile.log', '... got the right logfile dep');
 
 is($c->fetch('logger/log_file')->service, $c->fetch('log_file'), '... got the right value');
 is($c->fetch('logger/log_file')->get, 'logfile.log', '... got the right value');
+
+is($c->resolve( service => 'Database/host'), undef, '... service where value is undef');
 
 my $dbh = $c->resolve( service => 'Database/dbh' );
 isa_ok($dbh, 'DBI');


### PR DESCRIPTION
There's no reason this should not be allowed.