### PR TITLE
Fix dumping of parameterized containers

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Bread-Board
   [ API CHANGES ]
 
   [ BUG FIXES ]
+     - fixed Bread::Board::Dumper to dump parameterized containers -
+       previously it would just ignore them entirely (#56, Dave Rolsky)
 
   [ DOCUMENTATION ]
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@ Revision history for Bread-Board
   [ DOCUMENTATION ]
 
   [ ENHANCEMENTS ]
+     - Bread::Board::Dumper now sorts services and sub containers - previously
+       these came out in a random order each time (#56, Dave Rolsky)
 
   [ NEW FEATURES ]
 

--- a/lib/Bread/Board/Container/Parameterized.pm
+++ b/lib/Bread/Board/Container/Parameterized.pm
@@ -32,12 +32,14 @@ has 'container' => (
         has_service
         get_service_list
         has_services
+        services
 
         add_sub_container
         get_sub_container
         has_sub_container
         get_sub_container_list
         has_sub_containers
+        sub_containers
     ]]
 );
 

--- a/lib/Bread/Board/Dumper.pm
+++ b/lib/Bread/Board/Dumper.pm
@@ -17,8 +17,9 @@ sub dump {
         $output .= join('', $indent, "service: ", $thing->name, "\n" );
 
         if ($thing->does('Bread::Board::Service::WithDependencies')) {
-            while (my($key, $value) = each %{ $thing->dependencies }) {
-                $output .= $self->dump($value, $indent);
+            my $deps = $thing->dependencies;
+            for my $key (sort keys %{$deps}) {
+                $output .= $self->dump($deps->{$key}, $indent);
             }
         }
     }
@@ -41,13 +42,14 @@ sub _dump_container {
 
     my $output = '';
 
-    my ($key, $value);
-    while (($key, $value) = each %{ $c->sub_containers }) {
-        $output .= $self->dump($value, $indent);
+    my $subs = $c->sub_containers;
+    for my $key (sort keys %{$subs}) {
+        $output .= $self->dump($subs->{$key}, $indent);
     }
 
-    while (($key, $value) = each %{ $c->services }) {
-        $output .= $self->dump($value, $indent);
+    my $services = $c->services;
+    for my $key (sort keys %{$services}) {
+        $output .= $self->dump($services->{$key}, $indent);
     }
 
     return $output;

--- a/lib/Bread/Board/Dumper.pm
+++ b/lib/Bread/Board/Dumper.pm
@@ -25,15 +25,29 @@ sub dump {
     elsif ($thing->isa('Bread::Board::Container')) {
         $output = join('', $indent, "container: ", $thing->name, "\n" );
 
-        my ($key, $value);
+        $output .= $self->_dump_container($thing, $indent);
+    }
+    elsif ($thing->isa('Bread::Board::Container::Parameterized')) {
+        my $params = join ', ', @{ $thing->allowed_parameter_names };
+        $output = join('', $indent, "container: ", $thing->name, " [$params]\n" );
+        $output .= $self->_dump_container($thing, $indent);
+    }
 
-        while (($key, $value) = each %{ $thing->sub_containers }) {
-            $output .= $self->dump($value, $indent);
-        }
+    return $output;
+}
 
-        while (($key, $value) = each %{ $thing->services }) {
-            $output .= $self->dump($value, $indent);
-        }
+sub _dump_container {
+    my ($self, $c, $indent) = @_;
+
+    my $output = '';
+
+    my ($key, $value);
+    while (($key, $value) = each %{ $c->sub_containers }) {
+        $output .= $self->dump($value, $indent);
+    }
+
+    while (($key, $value) = each %{ $c->services }) {
+        $output .= $self->dump($value, $indent);
     }
 
     return $output;


### PR DESCRIPTION
Previously these were ignored entirely, which was very confusing.