### PR TITLE
- Proposed fix for pod error as reported by CPANTS.

### DIFF
--- a/lib/Bread/Board/Literal.pm
+++ b/lib/Bread/Board/Literal.pm
@@ -72,8 +72,6 @@ See L<Scalar::Util/weaken>.
 
 =head1 METHODS
 
-=over 4
-
 =attr C<value>
 
 Required attribute with read/write accessor. This is the value that


### PR DESCRIPTION
Hi @stevan 

Please review the PR, proposed fix for the following error:  

    Error: Bread-Board-0.35/lib/Bread/Board/Literal.pm -- Around line 95: You forgot a '=back' before '=head2'

Many Thanks.
Best Regards,
Mohammad S Anwar