### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 ---
+os: linux
+arch:
+ - amd64
+ - ppc64le
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - rm .travis.yml


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
